### PR TITLE
Gzip files after generating them

### DIFF
--- a/build_route_info.sh
+++ b/build_route_info.sh
@@ -1,4 +1,4 @@
-t!/bin/bash
+#!/bin/bash
 
 # Assumes split_uk_osm.sh is done
 

--- a/build_route_info.sh
+++ b/build_route_info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+t!/bin/bash
 
 # Assumes split_uk_osm.sh is done
 
@@ -17,7 +17,8 @@ IFS=$'\n'
 for osm in uk_osm/out/*; do
 	geojson=$(basename $osm .osm).geojson
 	out=$(basename $osm .osm).bin
-	pueue add -w importer --escape cargo run --release -- "../$osm" "../uk_osm/$geojson" "../route_info_files/$out"
+	task=$(pueue add --print-task-id --working-directory importer --escape cargo run --release -- "../$osm" "../uk_osm/$geojson" "../route_info_files/$out")
+	pueue add --after $task --escape gzip "route_info_files/$out"
 done
 
 # Manually wait for pueue to finish

--- a/build_route_info.sh
+++ b/build_route_info.sh
@@ -28,4 +28,20 @@ done
 # dev: aws s3 sync --dry route_info_files/ s3://atip.uk/route-info-dev/
 # If the same files are going in dev and prod, this saves bandwidth: aws s3 sync --dry s3://atip.uk/route-info/ s3://atip.uk/route-info-dev/
 
+# Make sure content-encoding is set to gzip for all the bin.gz files.
+# TODO On the next big upload, try adding the flag to the sync command above directly
+# To fix it after the fact:
+#
+# aws s3 cp \
+#        s3://atip.uk/route-info/ \       # or -dev
+#        s3://atip.uk/route-info/ \       # or -dev
+#        --exclude '*' \
+#        --include '*.gz' \
+#        --no-guess-mime-type \
+#        --content-encoding="gzip" \
+#        --metadata-directive="REPLACE" \
+#        --recursive
+#
+# You can test if this works: curl --head https://atip.uk/route-info/Derby.bin.gz | grep encoding
+
 # Have to invalidate the CDN manually! Use the S3 console

--- a/build_route_snappers.sh
+++ b/build_route_snappers.sh
@@ -16,8 +16,11 @@ IFS=$'\n'
 for osm in uk_osm/out/*; do
 	geojson=$(basename $osm .osm).geojson
 	out=$(basename $osm .osm).bin
-	pueue add --escape $bin -i "$osm" -b "uk_osm/$geojson" -o "route-snappers/$out"
+	task=$(pueue add --print-task-id --escape $bin -i "$osm" -b "uk_osm/$geojson" -o "route-snappers/$out")
+	pueue add --after $task --escape gzip "route-snappers/$out"
 done
+
+# Manually wait for pueue to finish
 
 # Put in S3
 # prod: aws s3 sync --dry route-snappers s3://atip.uk/route-snappers/

--- a/build_route_snappers.sh
+++ b/build_route_snappers.sh
@@ -25,5 +25,6 @@ done
 # Put in S3
 # prod: aws s3 sync --dry route-snappers s3://atip.uk/route-snappers/
 # dev: aws s3 sync --dry route-snappers s3://atip.uk/route-snappers-dev/
+# If the same files are going in dev and prod, this saves bandwidth: aws s3 sync --dry s3://atip.uk/route-snappers/ s3://atip.uk/route-snappers-dev/
 
 # Have to invalidate the CDN manually! Use the S3 console

--- a/build_route_snappers.sh
+++ b/build_route_snappers.sh
@@ -27,4 +27,20 @@ done
 # dev: aws s3 sync --dry route-snappers s3://atip.uk/route-snappers-dev/
 # If the same files are going in dev and prod, this saves bandwidth: aws s3 sync --dry s3://atip.uk/route-snappers/ s3://atip.uk/route-snappers-dev/
 
+# Make sure content-encoding is set to gzip for all the bin.gz files.
+# TODO On the next big upload, try adding the flag to the sync command above directly
+# To fix it after the fact:
+#
+# aws s3 cp \
+#        s3://atip.uk/route-snappers/ \       # or -dev
+#        s3://atip.uk/route-snappers/ \       # or -dev
+#        --exclude '*' \
+#        --include '*.gz' \
+#        --no-guess-mime-type \
+#        --content-encoding="gzip" \
+#        --metadata-directive="REPLACE" \
+#        --recursive
+#
+# You can test if this works: curl --head https://atip.uk/route-snappers/Derby.bin.gz | grep encoding
+
 # Have to invalidate the CDN manually! Use the S3 console


### PR DESCRIPTION
For https://github.com/acteng/atip/issues/57. My plan is to upload new bin.gz files and leave the existing .bin alone, then cutover ATIP to use bin.gz, and only delete the old .bin files after we update atip.uk files.

For context for Pete, this repo is for generating the route snapper and info files. https://github.com/acteng/abstreet-to-atip/ README should hopefully be good docs; if not, it's a good time to add to them!